### PR TITLE
fix-yarn-version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,16 @@
 FROM node:6.9.2 
 MAINTAINER tinytelly <dulwich22@gmail.com>
 
+# Install time and ts to get timing information
+RUN apt-get update && apt-get install -y time moreutils
+
 # Install Bower & Grunt
 RUN npm install -g bower grunt-cli && \
     echo '{ "allow_root": true }' > /root/.bowerrc
     
 RUN \
-	npm install -g ember-cli@2.10.0 &&\
-	npm install -g phantomjs@2.1.1 &&\
+	npm install -g ember-cli@2.7.0 &&\
+	npm install -g phantomjs-prebuilt@2.1.13 &&\
 	npm install -g yarn    
 
 # Define working directory.

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN \
 	npm install -g ember-cli@2.7.0 &&\
 	npm install -g phantomjs-prebuilt@2.1.13 &&\
 	npm install -g yarn
+	
+RUN pip install boto3 # required for s3_upload.py
 
 # Define working directory.
 WORKDIR /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:6.9.2
 MAINTAINER tinytelly <dulwich22@gmail.com>
 
 # Install time and ts to get timing information
-RUN apt-get update && apt-get install -y time moreutils python-pip python-dev build-essential
+RUN apt-get update && apt-get install -y time moreutils python-pip
 
 # Install Bower & Grunt
 RUN npm install -g bower grunt-cli && \
@@ -12,8 +12,7 @@ RUN npm install -g bower grunt-cli && \
 RUN \
 	npm install -g ember-cli@2.7.0 &&\
 	npm install -g phantomjs-prebuilt@2.1.13 &&\
-	npm install -g yarn &&\
-	npm install -g pip
+	npm install -g yarn
 
 # Define working directory.
 WORKDIR /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:6.9.2
 MAINTAINER tinytelly <dulwich22@gmail.com>
 
 # Install time and ts to get timing information
-RUN apt-get update && apt-get install -y time moreutils
+RUN apt-get update && apt-get install -y time moreutils python-pip python-dev build-essential
 
 # Install Bower & Grunt
 RUN npm install -g bower grunt-cli && \
@@ -12,7 +12,8 @@ RUN npm install -g bower grunt-cli && \
 RUN \
 	npm install -g ember-cli@2.7.0 &&\
 	npm install -g phantomjs-prebuilt@2.1.13 &&\
-	npm install -g yarn    
+	npm install -g yarn &&\
+	npm install -g pip
 
 # Define working directory.
 WORKDIR /data

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-docker file for : node, ember, bower, phantomjs, yarn, python, pip, time, moreutils, amazon AWS support support via boto3
+###docker file for : node, ember, bower, phantomjs, yarn, python, pip, time, moreutils, amazon AWS support support via boto3

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-docker file for : ember, bower, phantomjs, yarn
+docker file for : node, ember, bower, phantomjs, yarn, python, pip, time, moreutils, amazon AWS support support via boto3


### PR DESCRIPTION
Installs Yarn from package repo rather than using npm. Fixes the Yarn version at 0.17.10 (as per current image). Uses Yarn rather than npm for installing global libs. Fixes bower version at 1.8.0.